### PR TITLE
export  sharedLib namePrefix to buildConfigField

### DIFF
--- a/app/src/main/java/com/example/hellojni/HelloJni.java
+++ b/app/src/main/java/com/example/hellojni/HelloJni.java
@@ -19,6 +19,8 @@ import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.widget.TextView;
 
+import com.bennyhuo.kotlin.nativelib.BuildConfig;
+
 public class HelloJni extends AppCompatActivity {
 
     @Override
@@ -70,6 +72,6 @@ public class HelloJni extends AppCompatActivity {
      * installation time by the package manager.
      */
     static {
-        System.loadLibrary("knlib");
+        System.loadLibrary(BuildConfig.JNI_SHARED_LIB_NAME_PREFIX);
     }
 }

--- a/nativeLib/build.gradle.kts
+++ b/nativeLib/build.gradle.kts
@@ -3,18 +3,20 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.konan.target.KonanTarget.*
 
 plugins {
-    kotlin("multiplatform") version "1.7.10"
+    kotlin("multiplatform") version "1.7.22"
     id("com.android.library")
 }
 
 val jniLibDir = File(project.buildDir, arrayOf("generated", "jniLibs").joinToString(File.separator))
+
+val sharedLib_name_prefix = "knlib"
 
 kotlin {
     android()
 
     val nativeConfigure: KotlinNativeTarget.() -> Unit = {
         binaries {
-            sharedLib("knlib") {
+            sharedLib(sharedLib_name_prefix) {
                 linkTask.doLast {
                     copy {
                         from(outputFile)
@@ -67,6 +69,11 @@ android {
     defaultConfig {
         minSdk = 23
         targetSdk = 33
+        buildConfigField(
+            "String",
+            "JNI_SHARED_LIB_NAME_PREFIX",
+            "$sharedLib_name_prefix"
+        )
     }
 
     sourceSets {


### PR DESCRIPTION
export  sharedLib namePrefix to buildConfigField

val sharedLib_name_prefix = "knlib"

sharedLib(sharedLib_name_prefix)

 buildConfigField(
            "String",
            "JNI_SHARED_LIB_NAME_PREFIX",
            "$sharedLib_name_prefix"
        )

 System.loadLibrary(BuildConfig.JNI_SHARED_LIB_NAME_PREFIX);